### PR TITLE
feat: add HashPuzzle script template

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The goal of this repository is to provide a place where developers from around t
 | [BSV20](template/bsv20)             | BSV20 token standard implementation                         |
 | [BSV21](template/bsv21)             | BSV21 token standard implementation including LTM and POW20 |
 | [Cosign](template/cosign)           | Co-signing transactions with multiple parties               |
+| [HashPuzzle](template/hashpuzzle)   | SHA-256 hash puzzle — spend by revealing a secret preimage  |
 | [Inscription](template/inscription) | On-chain NFT-like inscriptions                              |
 | [Lockup](template/lockup)           | Time-locked transactions                                    |
 | [OrdLock](template/ordlock)         | Locking and unlocking functionality for ordinals            |

--- a/template/hashpuzzle/hashpuzzle.go
+++ b/template/hashpuzzle/hashpuzzle.go
@@ -1,0 +1,134 @@
+// Package hashpuzzle implements a hash puzzle script template.
+//
+// A hash puzzle locks satoshis to the SHA-256 hash of a secret preimage;
+// whoever reveals the preimage can spend the output. The script pattern is:
+//
+//	Locking script:   OP_SHA256 <32-byte hash> OP_EQUAL
+//	Unlocking script: <secret>
+//
+// Spending requires no signature, which makes unlocking cheap to construct
+// (no ECDSA signing, no key management) and keeps unlocking scripts small
+// (~33 bytes for a 32-byte secret vs ~107 bytes for P2PKH). The trade-off is
+// that the unlocking data does not commit to the spending transaction: once a
+// preimage is revealed, anyone who sees it can claim the output. Use only
+// where that is acceptable — small-value outputs, atomic-swap legs, or
+// high-throughput fee-fuel pools.
+//
+// This is a Go port of the HashPuzzle ScriptTemplate used in the
+// truth-machine demo (github.com/bsv-blockchain-demos/truth-machine).
+package hashpuzzle
+
+import (
+	"crypto/rand"
+	"errors"
+
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/hash"
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// SecretLength is the preimage length produced by GenerateSecretPair.
+const SecretLength = 32
+
+// HashLength is the required length of the SHA-256 hash in the locking script.
+const HashLength = 32
+
+var (
+	ErrInvalidHashLength = errors.New("hash must be 32 bytes")
+	ErrNoSecret          = errors.New("secret (preimage) not supplied")
+)
+
+// HashPuzzle holds the decoded form of a hash puzzle locking script.
+type HashPuzzle struct {
+	Hash []byte `json:"hash"`
+}
+
+// Lock creates a locking script that can only be spent by revealing a
+// preimage whose SHA-256 digest equals hash32: OP_SHA256 <hash32> OP_EQUAL.
+func Lock(hash32 []byte) (*script.Script, error) {
+	if len(hash32) != HashLength {
+		return nil, ErrInvalidHashLength
+	}
+	scr := script.Script(make([]byte, 0, HashLength+3))
+	s := &scr
+	_ = s.AppendOpcodes(script.OpSHA256)
+	if err := s.AppendPushData(hash32); err != nil {
+		return nil, err
+	}
+	_ = s.AppendOpcodes(script.OpEQUAL)
+	return s, nil
+}
+
+// Decode returns the HashPuzzle encoded by s, or nil when s is not a
+// canonical hash puzzle locking script.
+func Decode(s *script.Script) *HashPuzzle {
+	chunks, err := s.Chunks()
+	if err != nil || len(chunks) != 3 {
+		return nil
+	}
+	if chunks[0].Op == script.OpSHA256 &&
+		len(chunks[1].Data) == HashLength &&
+		chunks[2].Op == script.OpEQUAL {
+		return &HashPuzzle{Hash: chunks[1].Data}
+	}
+	return nil
+}
+
+// Unlock returns an unlocking template that reveals the secret preimage.
+func Unlock(secret []byte) (*HashPuzzleUnlocker, error) {
+	if len(secret) == 0 {
+		return nil, ErrNoSecret
+	}
+	return &HashPuzzleUnlocker{Secret: secret}, nil
+}
+
+// HashPuzzleUnlocker satisfies a hash puzzle by pushing the secret preimage.
+// It implements the go-sdk transaction.UnlockingScriptTemplate interface.
+type HashPuzzleUnlocker struct {
+	Secret []byte
+}
+
+// Sign returns the unlocking script. No signature is produced — the script is
+// a single push of the secret and does not depend on the transaction.
+func (h *HashPuzzleUnlocker) Sign(_ *transaction.Transaction, _ uint32) (*script.Script, error) {
+	if len(h.Secret) == 0 {
+		return nil, ErrNoSecret
+	}
+	s := &script.Script{}
+	if err := s.AppendPushData(h.Secret); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// EstimateLength returns the exact unlocking script length for the secret.
+func (h *HashPuzzleUnlocker) EstimateLength(_ *transaction.Transaction, _ uint32) uint32 {
+	return pushDataLength(len(h.Secret))
+}
+
+// pushDataLength returns the serialized length of a single minimal push of n
+// bytes of data.
+func pushDataLength(n int) uint32 {
+	un := uint32(n) //nolint:gosec // n is a script push length, far below MaxUint32
+	switch {
+	case n <= 75:
+		return un + 1
+	case n <= 0xff:
+		return un + 2 // OP_PUSHDATA1 <len>
+	case n <= 0xffff:
+		return un + 3 // OP_PUSHDATA2 <len:2>
+	default:
+		return un + 5 // OP_PUSHDATA4 <len:4>
+	}
+}
+
+// GenerateSecretPair returns a fresh random 32-byte secret and its SHA-256
+// hash, mirroring the truth-machine HashPuzzle.generateSecretPair helper.
+// Use the hash in Lock and keep the secret for Unlock.
+func GenerateSecretPair() (secret, hash32 []byte, err error) {
+	secret = make([]byte, SecretLength)
+	if _, err = rand.Read(secret); err != nil {
+		return nil, nil, err
+	}
+	return secret, primitives.Sha256(secret), nil
+}

--- a/template/hashpuzzle/hashpuzzle_test.go
+++ b/template/hashpuzzle/hashpuzzle_test.go
@@ -80,7 +80,7 @@ func TestUnlock_EstimateLengthMatchesActual(t *testing.T) {
 
 		unlockingScript, err := unlocker.Sign(nil, 0)
 		require.NoError(t, err)
-		require.Equal(t, int(unlocker.EstimateLength(nil, 0)), len(*unlockingScript),
+		require.Len(t, *unlockingScript, int(unlocker.EstimateLength(nil, 0)),
 			"estimate must match actual for secret length %d", n)
 	}
 }

--- a/template/hashpuzzle/hashpuzzle_test.go
+++ b/template/hashpuzzle/hashpuzzle_test.go
@@ -1,0 +1,147 @@
+package hashpuzzle
+
+import (
+	"testing"
+
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/hash"
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/script/interpreter"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateSecretPair(t *testing.T) {
+	secret, hash32, err := GenerateSecretPair()
+	require.NoError(t, err)
+	require.Len(t, secret, SecretLength)
+	require.Len(t, hash32, HashLength)
+	require.Equal(t, primitives.Sha256(secret), hash32)
+
+	secret2, _, err := GenerateSecretPair()
+	require.NoError(t, err)
+	require.NotEqual(t, secret, secret2, "secrets must be random")
+}
+
+func TestLockAndDecode_RoundTrip(t *testing.T) {
+	_, hash32, err := GenerateSecretPair()
+	require.NoError(t, err)
+
+	lockingScript, err := Lock(hash32)
+	require.NoError(t, err)
+	require.Len(t, []byte(*lockingScript), HashLength+3) // OP_SHA256 + push(1+32) + OP_EQUAL
+
+	decoded := Decode(lockingScript)
+	require.NotNil(t, decoded)
+	require.Equal(t, hash32, decoded.Hash)
+}
+
+func TestLock_InvalidHashLength(t *testing.T) {
+	_, err := Lock([]byte{0x01, 0x02})
+	require.ErrorIs(t, err, ErrInvalidHashLength)
+
+	_, err = Lock(make([]byte, 33))
+	require.ErrorIs(t, err, ErrInvalidHashLength)
+}
+
+func TestDecode_InvalidScripts(t *testing.T) {
+	// Not a script with 3 chunks
+	invalid := script.Script([]byte{0x00, 0x01})
+	require.Nil(t, Decode(&invalid))
+
+	// Right shape, wrong opcodes (P2PKH-ish)
+	s := &script.Script{}
+	_ = s.AppendOpcodes(script.OpDUP)
+	_ = s.AppendPushData(make([]byte, 32))
+	_ = s.AppendOpcodes(script.OpEQUAL)
+	require.Nil(t, Decode(s))
+
+	// Wrong hash length
+	s = &script.Script{}
+	_ = s.AppendOpcodes(script.OpSHA256)
+	_ = s.AppendPushData(make([]byte, 20))
+	_ = s.AppendOpcodes(script.OpEQUAL)
+	require.Nil(t, Decode(s))
+}
+
+func TestUnlock_Validation(t *testing.T) {
+	_, err := Unlock(nil)
+	require.ErrorIs(t, err, ErrNoSecret)
+
+	unlocker, err := Unlock([]byte("secret"))
+	require.NoError(t, err)
+	require.NotNil(t, unlocker)
+}
+
+func TestUnlock_EstimateLengthMatchesActual(t *testing.T) {
+	for _, n := range []int{1, 32, 75, 76, 255, 256} {
+		secret := make([]byte, n)
+		unlocker, err := Unlock(secret)
+		require.NoError(t, err)
+
+		unlockingScript, err := unlocker.Sign(nil, 0)
+		require.NoError(t, err)
+		require.Equal(t, int(unlocker.EstimateLength(nil, 0)), len(*unlockingScript),
+			"estimate must match actual for secret length %d", n)
+	}
+}
+
+// TestSpend_InterpreterValidates locks an output with a hash puzzle, spends it
+// revealing the preimage, and validates the pair with the go-sdk interpreter.
+func TestSpend_InterpreterValidates(t *testing.T) {
+	secret, hash32, err := GenerateSecretPair()
+	require.NoError(t, err)
+
+	lockingScript, err := Lock(hash32)
+	require.NoError(t, err)
+
+	sourceTx := transaction.NewTransaction()
+	sourceTx.AddOutput(&transaction.TransactionOutput{
+		Satoshis:      240,
+		LockingScript: lockingScript,
+	})
+
+	spendTx := transaction.NewTransaction()
+	unlocker, err := Unlock(secret)
+	require.NoError(t, err)
+	spendTx.AddInputFromTx(sourceTx, 0, unlocker)
+
+	require.NoError(t, spendTx.Sign())
+
+	err = interpreter.NewEngine().Execute(
+		interpreter.WithTx(spendTx, 0, sourceTx.Outputs[0]),
+		interpreter.WithForkID(),
+		interpreter.WithAfterGenesis(),
+	)
+	require.NoError(t, err, "interpreter must accept the revealed preimage")
+}
+
+// TestSpend_WrongSecretFails proves a wrong preimage is rejected.
+func TestSpend_WrongSecretFails(t *testing.T) {
+	_, hash32, err := GenerateSecretPair()
+	require.NoError(t, err)
+	wrongSecret, _, err := GenerateSecretPair()
+	require.NoError(t, err)
+
+	lockingScript, err := Lock(hash32)
+	require.NoError(t, err)
+
+	sourceTx := transaction.NewTransaction()
+	sourceTx.AddOutput(&transaction.TransactionOutput{
+		Satoshis:      240,
+		LockingScript: lockingScript,
+	})
+
+	spendTx := transaction.NewTransaction()
+	unlocker, err := Unlock(wrongSecret)
+	require.NoError(t, err)
+	spendTx.AddInputFromTx(sourceTx, 0, unlocker)
+
+	require.NoError(t, spendTx.Sign())
+
+	err = interpreter.NewEngine().Execute(
+		interpreter.WithTx(spendTx, 0, sourceTx.Outputs[0]),
+		interpreter.WithForkID(),
+		interpreter.WithAfterGenesis(),
+	)
+	require.Error(t, err, "interpreter must reject a wrong preimage")
+}


### PR DESCRIPTION
## What Changed
- Adds `template/hashpuzzle`: a SHA-256 hash puzzle script template — a Go port of the `HashPuzzle` ScriptTemplate used in the truth-machine demo ([bsv-blockchain-demos/truth-machine](https://github.com/bsv-blockchain-demos/truth-machine)).
  - `Lock(hash)` builds `OP_SHA256 <32-byte hash> OP_EQUAL`.
  - `Unlock(secret)` returns a go-sdk `transaction.UnlockingScriptTemplate` whose `Sign` pushes the bare preimage (no signature) and whose `EstimateLength` is exact for any secret length (minimal-push encoding aware).
  - `Decode(script)` recognizes canonical hash puzzle locking scripts.
  - `GenerateSecretPair()` mirrors the TS static helper: `crypto/rand` 32-byte secret + its SHA-256 hash.
- Adds the HashPuzzle row to the README's Available Templates table.

## Why It Was Necessary
- Hash puzzles let outputs be spent by revealing a preimage instead of producing an ECDSA signature — cheap to construct, no key management, and unlocking scripts of ~33 bytes vs ~107 for P2PKH. Useful for small-value outputs, atomic-swap legs, and high-throughput fee-fuel pools (motivating use case: the wallet-toolbox high-throughput UTXO management proposal, bsv-blockchain/go-wallet-toolbox#936).
- The package documentation states the trade-off plainly: the preimage does not commit to the spending transaction, so once revealed anyone who sees it can claim the output — use only where that is acceptable.

## Testing Performed
- 8 tests, all passing (`go test ./template/hashpuzzle/`): secret-pair generation, Lock/Decode round-trip, invalid-input validation for Lock/Unlock/Decode, exact EstimateLength across push-encoding boundaries (1–256 bytes), and two end-to-end go-sdk interpreter executions proving a correct preimage validates a spend and a wrong preimage is rejected.
- `go vet` clean.

## Impact / Risk
- Purely additive: new package plus one README table row; no changes to existing templates or dependencies.

## Notifications
- @sirdeggen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3WQjBJkXrUzPJouK98Zy4

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3WQjBJkXrUzPJouK98Zy4)_